### PR TITLE
find and skip the field deeply in 'and' and 'or' where options for smart aggregation

### DIFF
--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -85,6 +85,7 @@ class AggsTest < Minitest::Test
 
   def test_skip_complex
     assert_equal ({1 => 1, 2 => 1}), store_agg(where: {store_id: 2, price: {gt: 5}}, aggs: [:store_id])
+    assert_equal ({1 => 1, 2 => 1}), store_agg(where: {_and: [{_or: [{store_id: 2}, {store_id: 3}]}], price: {gt: 5}}, aggs: [:store_id])
   end
 
   def test_multiple


### PR DESCRIPTION
Required in case of aggregations over multiple range filter with multiple conditions